### PR TITLE
Added mermaidTooltip under figure

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -97,7 +97,7 @@ class listener implements EventSubscriberInterface
 		$mermaid = [
 			'bbcode_tag'	=> 'mermaid',
 			'bbcode_match'	=> '[mermaid #disableAutoLineBreaks=true #createParagraphs=false #ignoreTags=true]{TEXT}[/mermaid]',
-			'bbcode_tpl'	=> '<figure class="mermaid">{TEXT}</figure>'
+			'bbcode_tpl'	=> '<figure class="mermaid">{TEXT}</figure><div class="mermaidTooltip"></div>'
 		];
 
 		// Remove previous definitions

--- a/event/listener.php
+++ b/event/listener.php
@@ -97,7 +97,7 @@ class listener implements EventSubscriberInterface
 		$mermaid = [
 			'bbcode_tag'	=> 'mermaid',
 			'bbcode_match'	=> '[mermaid #disableAutoLineBreaks=true #createParagraphs=false #ignoreTags=true]{TEXT}[/mermaid]',
-			'bbcode_tpl'	=> '<figure class="mermaid">{TEXT}</figure><div class="mermaidTooltip"></div>'
+			'bbcode_tpl'	=> '<div class="mermaid-wrapper"><figure class="mermaid">{TEXT}</figure><div class="mermaidTooltip"></div></div>'
 		];
 
 		// Remove previous definitions

--- a/tests/functional/mermaid_test.php
+++ b/tests/functional/mermaid_test.php
@@ -47,13 +47,28 @@ EOT;
 			$this->sid
 		));
 
-		$expected = <<<EOT
+		if (version_compare(PHP_VERSION, '7.3.0', '<'))
+		{
+			$expected = <<<EOT
+<div class="mermaid-wrapper">
 <figure class="mermaid">graph TD;
     A--&gt;B;
     A--&gt;C;
     B--&gt;D;
-    C--&gt;D;</figure>
+    C--&gt;D;</figure><div class="mermaidTooltip"></div>
+</div>
 EOT;
+		}
+		else
+		{
+			$expected = <<<EOT
+<div class="mermaid-wrapper"><figure class="mermaid">graph TD;
+    A--&gt;B;
+    A--&gt;C;
+    B--&gt;D;
+    C--&gt;D;</figure><div class="mermaidTooltip"></div></div>
+EOT;
+		}
 
 		$result = $crawler->filter(sprintf(
 			'#post_content%d .content',


### PR DESCRIPTION
Mermaid gives you an option for callbacks in the code, one of these is the tooltip that will show in a div with the class "mermaidTooltip". When Mermaid does not find this div it will append one to the body. Making it very hard to see and read in the current implementation.

<img width="666" alt="image" src="https://user-images.githubusercontent.com/3200970/180773021-1620df9f-53e7-420b-bf11-ae95c7515f53.png">

I've made a small edit so it will shown under the Mermaid figure. 

![image](https://user-images.githubusercontent.com/3200970/180773142-cbb19df9-b6db-4618-b5d3-67262ce7b21e.png)

Example mermaid graph
```
[mermaid]
flowchart LR
    id1{{Foobar}}-->id2[Barfoo]
    click id1 callback "Foobar is not Barfoo"
[/mermaid]
```